### PR TITLE
Update Atlas Version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ josm { // see https://floscher.github.io/gradle-josm-plugin/kdoc/v0.3.4/gradle-j
     manifest.minJosmVersion = '13957'
 }
 ext.versions = [
-    'atlas': '5.0.16'
+    'atlas': '5.2.9'
 ]
 
 // corresponds to POM description/group


### PR DESCRIPTION
This updates the atlas version to fix an error where metadata was required to open an atlas file. This was causing all new atlas files to be un-openable. 